### PR TITLE
Add FileCatalog/MetaCatalog option

### DIFF
--- a/source/AdministratorGuide/Configuration/ConfReference/Resources/FileCatalogs/index.rst
+++ b/source/AdministratorGuide/Configuration/ConfReference/Resources/FileCatalogs/index.rst
@@ -3,14 +3,16 @@ Resources / FileCatalogs - Subsections
 
 This subsection include the definition of the File Catalogs to be used in the installation. In case there is more than one File Catalog defined in this section, the first one in the section will be used as default by the ReplicaManager client.
 
-+--------------------------+-------------------------------------------------+-------------------------+
-| **Name**                 | **Description**                                 | **Example**             |
-+--------------------------+-------------------------------------------------+-------------------------+
-| *FileCatalog*            | Subsection used to configure DIRAC File catalog | FileCatalog             |
-+--------------------------+-------------------------------------------------+-------------------------+
-| *FileCatalog/AccessType* | Access type allowed to the particular catalog   | AccessType = Read-Write |
-+--------------------------+-------------------------------------------------+-------------------------+
-| *FileCatalog/Status*     | To define the catalog as active or inactive     | Status = Active         |
-+--------------------------+-------------------------------------------------+-------------------------+
++---------------------------+-------------------------------------------------+----------------------------+
+| **Name**                  | **Description**                                 | **Example**                |
++---------------------------+-------------------------------------------------+----------------------------+
+| *FileCatalog*             | Subsection used to configure DIRAC File catalog | FileCatalog                |
++---------------------------+-------------------------------------------------+----------------------------+
+| *FileCatalog/AccessType*  | Access type allowed to the particular catalog   | AccessType = Read-Write    |
++---------------------------+-------------------------------------------------+----------------------------+
+| *FileCatalog/Status*      | To define the catalog as active or inactive     | Status = Active            |
++---------------------------+-------------------------------------------------+----------------------------+
+| *FileCatalog/MetaCatalog* | If the Catalog is a MetaDataCatalog             | MetaCatalog = True         |
++---------------------------+-------------------------------------------------+----------------------------+
 
 


### PR DESCRIPTION
Add doc for new option for FileCatalogs
Enlarged table to have no line breaks.
@atsareg This new option goes here, right?
@fstagni I should still make the PR here, right? 
Also could someone re-create the documentation page?